### PR TITLE
Facets for documents list API

### DIFF
--- a/miller/api/pagination.py
+++ b/miller/api/pagination.py
@@ -1,0 +1,50 @@
+from collections import OrderedDict
+
+from django.db.models import Count
+from django.db.models.expressions import RawSQL
+from django.contrib.postgres.fields import JSONField
+
+from rest_framework.pagination import LimitOffsetPagination
+from rest_framework.response import Response
+
+
+class FacetedPagination(LimitOffsetPagination):
+
+    facets_queryset = None
+
+    def paginate_queryset(self, queryset, request, view=None):
+      self.facets_queryset = queryset
+      return super(FacetedPagination, self).paginate_queryset(queryset, request, view=view)
+
+    def get_paginated_response(self, data):
+      return Response(OrderedDict([
+          ('count', self.count),
+          ('next', self.get_next_link()),
+          ('previous', self.get_previous_link()),
+          ('results', data),
+          ('facets', self.get_facets()),
+      ]))
+
+    def get_facets(self):
+
+      facets = self.request.query_params.getlist("facets", [])
+      out_facets = {}
+
+      for facet in facets:
+          json_field = False
+          pieces = facet.split("__")
+          if len(pieces) > 1:
+            fieldname = pieces[0]
+            field_instance = self.facets_queryset.model._meta.get_field(fieldname)
+            if isinstance(field_instance, JSONField):
+                json_field = True
+          if json_field:
+            rawsql_field = "((%s->>%%s))" % fieldname
+            subfield = ("__").join(pieces[1:])
+            annotate_dict = { facet : RawSQL(rawsql_field, (subfield,)) }
+            counts = self.facets_queryset.annotate(**annotate_dict)\
+                .values(facet).annotate(count=Count(facet)).order_by(facet)
+          else:
+            counts = self.facets_queryset.values(facet).annotate(count=Count(facet)).order_by(facet)
+          out_facets[facet] = counts
+      return out_facets


### PR DESCRIPTION
This pull request implements "facets" parameter for documents list API.
You can specify facets in the querystring, in form of a multiple parameter called "facets"

```
http://localhost:8000/api/document/?filters={"data__type":"person"}&facets=data__activity__en&facets=data__birth_place
```

Parameters specified in the facets must be fields of the Document model, and also fields nested in PostgreSQL JSON field can be used.

The response will contain a new key, (in the root object), called "facets", that will contain, for each requested face, a count of all unique values for that field. 

The implementation is based on a custom paginator class derived from REST Framework `LimitOffsetPagination` class.

This is an example of result of a "faceted" query:

```
{
  "results" : [...],
  "count" : 123,
  ...,
  "facets": {
    "data__activity__en": [
      {
        "data__activity__en": "Adventurer/Archaeologist",
        "count": 1
      },
      {
        "data__activity__en": "Adventurer/Writer/Photographer",
        "count": 1
      },
      {
        "data__activity__en": "Agronomist/Author",
        "count": 1
      },
      {
        "data__activity__en": "Ambassador",
        "count": 1
      },
      {
        "data__activity__en": "Antiquary",
        "count": 1
      },
      {
        "data__activity__en": "Artist/Painter",
        "count": 1
      },
      {
        "data__activity__en": "Athlete/Soldier",
        "count": 1
      },
      {
        "data__activity__en": "Author",
        "count": 3
      },
      {
        "data__activity__en": "Author/Editor/Journalist",
        "count": 1
      },
      {
        "data__activity__en": "Author/Engeneer",
        "count": 1
      },
      {
        "data__activity__en": "Author/Industrialist",
        "count": 1
      },
      {
        "data__activity__en": "Author/Jurist/Activist",
        "count": 1
      },
      {
        "data__activity__en": "Author/Linguist",
        "count": 1
      },
      {
        "data__activity__en": "Author/Moviemaker",
        "count": 1
      },
      {
        "data__activity__en": "Author/Playwright",
        "count": 1
      },
      {
        "data__activity__en": "Author/Playwright/Linguist",
        "count": 1
      },
      {
        "data__activity__en": "Author/Poet",
        "count": 5
      },
      {
        "data__activity__en": "Author/Poet/Playwright/Politician",
        "count": 1
      },
      {
        "data__activity__en": "Author/Politician",
        "count": 1
      },
      {
        "data__activity__en": "Author/Soldier",
        "count": 2
      },
      {
        "data__activity__en": "Author/Teacher",
        "count": 3
      },
      {
        "data__activity__en": "Banker",
        "count": 1
      },
      {
        "data__activity__en": "Businessman/Politician",
        "count": 2
      },
      {
        "data__activity__en": "Clerk to the Grand-Ducal Court",
        "count": 1
      },
      {
        "data__activity__en": "Diplomat",
        "count": 2
      },
      {
        "data__activity__en": "Economist/Historian",
        "count": 1
      },
      {
        "data__activity__en": "Editor",
        "count": 3
      },
      {
        "data__activity__en": "Engineer",
        "count": 1
      },
      {
        "data__activity__en": "Engineer/Businessman",
        "count": 1
      },
      {
        "data__activity__en": "Entrepreneur/Industrialist",
        "count": 1
      },
      {
        "data__activity__en": "Forester/Author",
        "count": 1
      },
      {
        "data__activity__en": "Historian/Journalist",
        "count": 1
      },
      {
        "data__activity__en": "Historian/Jurist",
        "count": 1
      },
      {
        "data__activity__en": "Industrialist",
        "count": 4
      },
      {
        "data__activity__en": "Industrialist/Businessman",
        "count": 1
      },
      {
        "data__activity__en": "Industrialist/Politician",
        "count": 2
      },
      {
        "data__activity__en": "Industrialist/voluntary soldier",
        "count": 1
      },
      {
        "data__activity__en": "Journalist",
        "count": 2
      },
      {
        "data__activity__en": "Journalist/Author",
        "count": 1
      },
      {
        "data__activity__en": "Journalist/Politician",
        "count": 1
      },
      {
        "data__activity__en": "Journalist/Soldier",
        "count": 1
      },
      {
        "data__activity__en": "Jurist",
        "count": 1
      },
      {
        "data__activity__en": "Jurist/Politician",
        "count": 1
      },
      {
        "data__activity__en": "Lawyer/Politician/Industrialist",
        "count": 1
      },
      {
        "data__activity__en": "Lieutenant-Colonel",
        "count": 1
      },
      {
        "data__activity__en": "Major General",
        "count": 1
      },
      {
        "data__activity__en": "Military",
        "count": 1
      },
      {
        "data__activity__en": "Military Officer",
        "count": 14
      },
      {
        "data__activity__en": "Military figure",
        "count": 2
      },
      {
        "data__activity__en": "Monarch",
        "count": 4
      },
      {
        "data__activity__en": "Photographer",
        "count": 2
      },
      {
        "data__activity__en": "Physician/Author",
        "count": 1
      },
      {
        "data__activity__en": "Poet",
        "count": 1
      },
      {
        "data__activity__en": "Politician",
        "count": 20
      },
      {
        "data__activity__en": "Politician/Industrialist",
        "count": 2
      },
      {
        "data__activity__en": "Professor",
        "count": 1
      },
      {
        "data__activity__en": "Publicist/Activist",
        "count": 1
      },
      {
        "data__activity__en": "Publicist/Editor",
        "count": 1
      },
      {
        "data__activity__en": "Soldier",
        "count": 7
      },
      {
        "data__activity__en": "Soldier/Photographer",
        "count": 1
      },
      {
        "data__activity__en": "Soldier/Pilot",
        "count": 1
      },
      {
        "data__activity__en": "Spy",
        "count": 1
      },
      {
        "data__activity__en": "Teacher/Author/Editor",
        "count": 1
      },
      {
        "data__activity__en": "Teacher/Philologist",
        "count": 1
      },
      {
        "data__activity__en": "Unknown",
        "count": 7
      },
      {
        "data__activity__en": "Writer/Historian",
        "count": 1
      }
    ],
    "data__birth_place": [
      {
        "count": 1,
        "data__birth_place": null
      },
      {
        "count": 1,
        "data__birth_place": "Altlinster"
      },
      {
        "count": 1,
        "data__birth_place": "Angers (FR)"
      },
      {
        "count": 1,
        "data__birth_place": "Audun-le-Tiche (FR)"
      },
      {
        "count": 1,
        "data__birth_place": "Aulnay-sur-Iton (FR)"
      },
      {
        "count": 1,
        "data__birth_place": "Avesnes (FR)"
      },
      {
        "count": 1,
        "data__birth_place": "Barnstaple (UK)"
      },
      {
        "count": 1,
        "data__birth_place": "Bech-Kleinmacher"
      },
      {
        "count": 1,
        "data__birth_place": "Berbourg (LU)"
      },
      {
        "count": 1,
        "data__birth_place": "Berg/Betzdorf"
      },
      {
        "count": 3,
        "data__birth_place": "Berlin"
      },
      {
        "count": 1,
        "data__birth_place": "Bidestroff (FR)"
      },
      {
        "count": 1,
        "data__birth_place": "Biesme (BE)"
      },
      {
        "count": 1,
        "data__birth_place": "Bivange (LU)"
      },
      {
        "count": 1,
        "data__birth_place": "Boevange-sur-Attert"
      },
      {
        "count": 1,
        "data__birth_place": "Bofferdange (LU)"
      },
      {
        "count": 1,
        "data__birth_place": "Bonnevoie"
      },
      {
        "count": 1,
        "data__birth_place": "Born (LU)"
      },
      {
        "count": 1,
        "data__birth_place": "Bourgneuf (FR)"
      },
      {
        "count": 5,
        "data__birth_place": "Brussels"
      },
      {
        "count": 1,
        "data__birth_place": "Charmes (FR)"
      },
      {
        "count": 1,
        "data__birth_place": "Charnay (FR)"
      },
      {
        "count": 2,
        "data__birth_place": "Colmar-Berg"
      },
      {
        "count": 1,
        "data__birth_place": "Cologne (DE)"
      },
      {
        "count": 6,
        "data__birth_place": "Diekirch"
      },
      {
        "count": 1,
        "data__birth_place": "Differdange"
      },
      {
        "count": 1,
        "data__birth_place": "Dommeldange"
      },
      {
        "count": 1,
        "data__birth_place": "Donkols"
      },
      {
        "count": 1,
        "data__birth_place": "Dudelange"
      },
      {
        "count": 1,
        "data__birth_place": "Ehnen"
      },
      {
        "count": 1,
        "data__birth_place": "Eich â€“ Luxembourg"
      },
      {
        "count": 2,
        "data__birth_place": "Eich, Luxembourg"
      },
      {
        "count": 2,
        "data__birth_place": "Esch-sur-Alzette"
      },
      {
        "count": 2,
        "data__birth_place": "France"
      },
      {
        "count": 1,
        "data__birth_place": "Frane"
      },
      {
        "count": 1,
        "data__birth_place": "Fromental (FR)"
      },
      {
        "count": 4,
        "data__birth_place": "Germany"
      },
      {
        "count": 1,
        "data__birth_place": "Ghent (BE)"
      },
      {
        "count": 1,
        "data__birth_place": "Heiderscheid"
      },
      {
        "count": 1,
        "data__birth_place": "Hohenfinow"
      },
      {
        "count": 1,
        "data__birth_place": "Hollerich"
      },
      {
        "count": 1,
        "data__birth_place": "Ixelles (BE)"
      },
      {
        "count": 1,
        "data__birth_place": "Jemeppe (BE)"
      },
      {
        "count": 1,
        "data__birth_place": "Laclede, Mo. (US)"
      },
      {
        "count": 1,
        "data__birth_place": "Le Creusot (FR)"
      },
      {
        "count": 1,
        "data__birth_place": "Limpertsberg"
      },
      {
        "count": 20,
        "data__birth_place": "Luxembourg"
      },
      {
        "count": 1,
        "data__birth_place": "Luxembourg "
      },
      {
        "count": 2,
        "data__birth_place": "Luxembourg City"
      },
      {
        "count": 1,
        "data__birth_place": "Mersch"
      },
      {
        "count": 1,
        "data__birth_place": "Mettman (DE)"
      },
      {
        "count": 1,
        "data__birth_place": "Mondercange"
      },
      {
        "count": 1,
        "data__birth_place": "Mondorf-les-Bains"
      },
      {
        "count": 1,
        "data__birth_place": "Mulheim (DE)"
      },
      {
        "count": 1,
        "data__birth_place": "MÃ©ziÃ¨res (FR)"
      },
      {
        "count": 1,
        "data__birth_place": "Ohio (US)"
      },
      {
        "count": 4,
        "data__birth_place": "Paris"
      },
      {
        "count": 3,
        "data__birth_place": "Paris (FR)"
      },
      {
        "count": 1,
        "data__birth_place": "Pettange"
      },
      {
        "count": 1,
        "data__birth_place": "Potsdam"
      },
      {
        "count": 1,
        "data__birth_place": "Remich (LU)"
      },
      {
        "count": 1,
        "data__birth_place": "Rennes (FR)"
      },
      {
        "count": 1,
        "data__birth_place": "Rumlange"
      },
      {
        "count": 1,
        "data__birth_place": "Septfontaines (LU)"
      },
      {
        "count": 1,
        "data__birth_place": "Stegen"
      },
      {
        "count": 2,
        "data__birth_place": "Steinsel"
      },
      {
        "count": 1,
        "data__birth_place": "Stockholm"
      },
      {
        "count": 1,
        "data__birth_place": "Tarbes (FR)"
      },
      {
        "count": 1,
        "data__birth_place": "Troisvierges"
      },
      {
        "count": 1,
        "data__birth_place": "Troisvierges (LU)"
      },
      {
        "count": 1,
        "data__birth_place": "Ulfingen"
      },
      {
        "count": 14,
        "data__birth_place": "Unknown"
      },
      {
        "count": 1,
        "data__birth_place": "Volkrange (FR)"
      },
      {
        "count": 1,
        "data__birth_place": "Wecker (LU)"
      },
      {
        "count": 1,
        "data__birth_place": "Weicherdange"
      },
      {
        "count": 1,
        "data__birth_place": "Weilerbach (DE)"
      },
      {
        "count": 1,
        "data__birth_place": "Weiswampach"
      }
    ]
  }
}
```